### PR TITLE
Correct Yuescript/Moonscript maintained status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ An intriguing new avenue of development started by [Rochus Keller](https://githu
 
 ### Tier 1
 For lack of a better designator, these projects are well known, or compiles existing languages
- - (*) http://yuescript.org/
+ - http://yuescript.org/
  Yuescript, an extended and actively developed form of Moonscript.
- - http://moonscript.org/
+ - (*) http://moonscript.org/
  Moonscript, indentation based syntax, based on the ideas of Coffeescript.
  - http://haxe.org
  Haxe, strongly typed OO language transpiler with multiple backends


### PR DESCRIPTION
I think you got these backwards - Moonscript is unmaintained, Yuescript is a maintained successor - the latest commit was 6 days ago.